### PR TITLE
Rename bat -> view

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,5 +1,4 @@
 crate mod args;
-crate mod bat;
 crate mod cd;
 crate mod command;
 crate mod ls;
@@ -10,6 +9,7 @@ crate mod skip;
 crate mod sort_by;
 crate mod take;
 crate mod to_array;
+crate mod view;
 crate mod where_;
 
 crate use to_array::to_array;

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -4,9 +4,9 @@ use derive_new::new;
 use prettyprint::PrettyPrinter;
 
 #[derive(new)]
-pub struct Bat;
+pub struct View;
 
-impl crate::Command for Bat {
+impl crate::Command for View {
     fn run(&self, args: CommandArgs<'caller>) -> Result<VecDeque<ReturnValue>, ShellError> {
         let target = match args.args.first() {
             // TODO: This needs better infra

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ fn main() -> Result<(), Box<Error>> {
             ("ps", Box::new(ps::Ps)),
             ("ls", Box::new(ls::Ls)),
             ("cd", Box::new(cd::Cd)),
-            ("bat", Box::new(bat::Bat)),
+            ("view", Box::new(view::View)),
             ("skip", Box::new(skip::Skip)),
             ("take", Box::new(take::Take)),
             ("select", Box::new(select::Select)),

--- a/src/shell/completer.rs
+++ b/src/shell/completer.rs
@@ -16,7 +16,7 @@ impl Completer for NuCompleter {
         context: &rustyline::Context,
     ) -> rustyline::Result<(usize, Vec<completion::Pair>)> {
         let commands = [
-            "ps", "ls", "cd", "bat", "skip", "take", "select", "reject", "to-array", "where",
+            "ps", "ls", "cd", "view", "skip", "take", "select", "reject", "to-array", "where",
             "sort-by",
         ];
 


### PR DESCRIPTION
Rename the "bat" command to "view" to make it easier for people who don't know what bat is.