### PR TITLE
Fix quoted string handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,6 @@ fn process_line(
 
             for item in parsed {
                 input = match process_command(
-                    crate::parser::print_items(&item),
                     item.clone(),
                     input,
                     context.clone(),
@@ -181,13 +180,13 @@ fn process_line(
 }
 
 fn process_command(
-    line: String,
     parsed: Vec<crate::parser::Item>,
     input: VecDeque<Value>,
     context: Arc<Mutex<Context>>,
 ) -> Result<VecDeque<Value>, ShellError> {
     let command = &parsed[0].name()?;
     let arg_list = parsed[1..].iter().map(|i| i.as_value()).collect();
+    let arg_list_strings: Vec<String> = parsed[1..].iter().map(|i| i.print()).collect();
 
     if command == &"format" {
         format(input, context);
@@ -225,7 +224,11 @@ fn process_command(
             }
 
             false => {
-                Exec::shell(line).cwd(ctx.env.cwd()).join().unwrap();
+                Exec::shell(command)
+                    .args(&arg_list_strings)
+                    .cwd(ctx.env.cwd())
+                    .join()
+                    .unwrap();
                 Ok(VecDeque::new())
             }
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,4 @@
 crate mod completer;
 crate mod parse;
 
-crate use self::parse::{print_items, shell_parser, Item};
+crate use self::parse::{shell_parser, Item};

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -65,18 +65,16 @@ impl Item {
             Item::Operator(o) => Value::Primitive(Primitive::Operator(o.clone())),
         }
     }
-}
 
-crate fn print_items(items: &[Item]) -> String {
-    let formatted = items.iter().map(|item| match item {
-        Item::Bare(s) => format!("{}", s),
-        Item::Quoted(s) => format!("{:?}", s),
-        Item::Int(i) => format!("{:?}", i),
-        Item::Boolean(b) => format!("{:?}", b),
-        Item::Operator(o) => o.print(),
-    });
-
-    itertools::join(formatted, " ")
+    pub fn print(&self) -> String {
+        match self {
+            Item::Bare(s) => format!("{}", s),
+            Item::Quoted(s) => format!("{}", s),
+            Item::Int(i) => format!("{:?}", i),
+            Item::Boolean(b) => format!("{:?}", b),
+            Item::Operator(o) => o.print(),
+        }
+    }
 }
 
 impl Item {


### PR DESCRIPTION
This fixes quoted strings as arguments, so you can now pass them to executed commands.