### PR TITLE
Fix bare dot paths and add dot paths to select

### DIFF
--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -29,7 +29,7 @@ crate enum TopToken {
     #[callback = "start_variable"]
     Dollar,
 
-    #[regex = r#"[^\s0-9"'$\-][^\s"'\.]*"#]
+    #[regex = r#"[^\s0-9"'$\-][^\s"']*"#]
     #[callback = "end_bare_variable"]
     Bare,
 


### PR DESCRIPTION
This changes how bare dot paths to include dots into the path, which can later be split. Added dot path splitting to select, so you can pass a dotted path for field selection.