### PR TITLE
Fix quoted strings in linux

### DIFF
--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -400,7 +400,7 @@ impl Leaf {
 
     fn as_external_arg(&self) -> String {
         match self {
-            Leaf::String(s) => format!("{}", s),
+            Leaf::String(s) => format!("\"{}\"", s),
             Leaf::Bare(path) => format!("{}", path.to_string()),
             Leaf::Boolean(b) => format!("{}", b),
             Leaf::Int(i) => format!("{}", i),


### PR DESCRIPTION
Fix writing quoted strings to external commands