### PR TITLE
Add pretty errors to commands

### DIFF
--- a/src/commands/command.rs
+++ b/src/commands/command.rs
@@ -1,54 +1,26 @@
 use crate::errors::ShellError;
 use crate::object::Value;
+use crate::parser::lexer::Span;
+use crate::parser::lexer::Spanned;
 use crate::parser::CommandConfig;
 use crate::prelude::*;
-use core::future::Future;
 use std::path::PathBuf;
 
 pub struct CommandArgs {
     pub host: Arc<Mutex<dyn Host + Send>>,
     pub env: Arc<Mutex<Environment>>,
-    pub positional: Vec<Value>,
+    pub name_span: Option<Span>,
+    pub positional: Vec<Spanned<Value>>,
     pub named: indexmap::IndexMap<String, Value>,
     pub input: InputStream,
 }
 
-impl CommandArgs {
-    crate fn from_context(
-        ctx: &'caller mut Context,
-        positional: Vec<Value>,
-        input: InputStream,
-    ) -> CommandArgs {
-        CommandArgs {
-            host: ctx.host.clone(),
-            env: ctx.env.clone(),
-            positional,
-            named: indexmap::IndexMap::default(),
-            input,
-        }
-    }
-}
-
 pub struct SinkCommandArgs {
     pub ctx: Context,
-    pub positional: Vec<Value>,
+    pub name_span: Option<Span>,
+    pub positional: Vec<Spanned<Value>>,
     pub named: indexmap::IndexMap<String, Value>,
     pub input: Vec<Value>,
-}
-
-impl SinkCommandArgs {
-    crate fn from_context(
-        ctx: &'caller mut Context,
-        positional: Vec<Value>,
-        input: Vec<Value>,
-    ) -> SinkCommandArgs {
-        SinkCommandArgs {
-            ctx: ctx.clone(),
-            positional,
-            named: indexmap::IndexMap::default(),
-            input,
-        }
-    }
 }
 
 #[derive(Debug)]

--- a/src/commands/first.rs
+++ b/src/commands/first.rs
@@ -4,7 +4,30 @@ use crate::prelude::*;
 // TODO: "Amount remaining" wrapper
 
 pub fn first(args: CommandArgs) -> Result<OutputStream, ShellError> {
-    let amount = args.positional[0].as_i64()?;
+    if args.positional.len() == 0 {
+        if let Some(span) = args.name_span {
+            return Err(ShellError::labeled_error(
+                "First requires an amount",
+                "needs parameter",
+                span,
+            ));
+        } else {
+            return Err(ShellError::string("first requires an amount."));
+        }
+    }
+
+    let amount = args.positional[0].as_i64();
+
+    let amount = match amount {
+        Ok(o) => o,
+        Err(_) => {
+            return Err(ShellError::labeled_error(
+                "Value is not a number",
+                "expected integer",
+                args.positional[0].span,
+            ))
+        }
+    };
 
     let input = args.input;
 

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -20,8 +20,16 @@ fn get_member(path: &str, obj: &Value) -> Option<Value> {
 }
 
 pub fn get(args: CommandArgs) -> Result<OutputStream, ShellError> {
-    if args.positional.is_empty() {
-        return Err(ShellError::string("select requires a field"));
+    if args.positional.len() == 0 {
+        if let Some(span) = args.name_span {
+            return Err(ShellError::labeled_error(
+                "Get requires a field or field path",
+                "needs parameter",
+                span,
+            ));
+        } else {
+            return Err(ShellError::string("get requires fields."));
+        }
     }
 
     let fields: Result<Vec<String>, _> = args.positional.iter().map(|a| a.as_string()).collect();

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -1,5 +1,6 @@
 use crate::errors::ShellError;
 use crate::object::{dir_entry_dict, Primitive, Value};
+use crate::parser::lexer::Spanned;
 use crate::prelude::*;
 use std::path::{Path, PathBuf};
 
@@ -7,12 +8,29 @@ pub fn ls(args: CommandArgs) -> Result<OutputStream, ShellError> {
     let cwd = args.env.lock().unwrap().cwd().to_path_buf();
     let mut full_path = PathBuf::from(cwd);
     match &args.positional.get(0) {
-        Some(Value::Primitive(Primitive::String(s))) => full_path.push(Path::new(s)),
+        Some(Spanned {
+            item: Value::Primitive(Primitive::String(s)),
+            ..
+        }) => full_path.push(Path::new(s)),
         _ => {}
     }
 
-    let entries =
-        std::fs::read_dir(&full_path).map_err(|e| ShellError::string(format!("{:?}", e)))?;
+    let entries = std::fs::read_dir(&full_path);
+
+    let entries = match entries {
+        Err(e) => {
+            if let Some(s) = args.positional.get(0) {
+                return Err(ShellError::labeled_error(
+                    e.to_string(),
+                    e.to_string(),
+                    s.span,
+                ));
+            } else {
+                return Err(ShellError::string(e.to_string()));
+            }
+        }
+        Ok(o) => o,
+    };
 
     let mut shell_entries = VecDeque::new();
 

--- a/src/commands/pick.rs
+++ b/src/commands/pick.rs
@@ -4,8 +4,16 @@ use crate::object::Value;
 use crate::prelude::*;
 
 pub fn pick(args: CommandArgs) -> Result<OutputStream, ShellError> {
-    if args.positional.is_empty() {
-        return Err(ShellError::string("select requires a field"));
+    if args.positional.len() == 0 {
+        if let Some(span) = args.name_span {
+            return Err(ShellError::labeled_error(
+                "Pick requires fields",
+                "needs parameter",
+                span,
+            ));
+        } else {
+            return Err(ShellError::string("pick requires fields."));
+        }
     }
 
     let fields: Result<Vec<String>, _> = args.positional.iter().map(|a| a.as_string()).collect();

--- a/src/commands/reject.rs
+++ b/src/commands/reject.rs
@@ -4,8 +4,16 @@ use crate::object::Value;
 use crate::prelude::*;
 
 pub fn reject(args: CommandArgs) -> Result<OutputStream, ShellError> {
-    if args.positional.is_empty() {
-        return Err(ShellError::string("select requires a field"));
+    if args.positional.len() == 0 {
+        if let Some(span) = args.name_span {
+            return Err(ShellError::labeled_error(
+                "Reject requires fields",
+                "needs parameter",
+                span,
+            ));
+        } else {
+            return Err(ShellError::string("reject requires fields."));
+        }
     }
 
     let fields: Result<Vec<String>, _> = args.positional.iter().map(|a| a.as_string()).collect();

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -1,7 +1,7 @@
 use crate::commands::command::SinkCommandArgs;
 use crate::errors::ShellError;
 use crate::object::{Primitive, Value};
-use crate::prelude::*;
+use crate::parser::lexer::Spanned;
 use std::path::{Path, PathBuf};
 
 pub fn save(args: SinkCommandArgs) -> Result<(), ShellError> {
@@ -11,13 +11,16 @@ pub fn save(args: SinkCommandArgs) -> Result<(), ShellError> {
 
     let cwd = args.ctx.env.lock().unwrap().cwd().to_path_buf();
     let mut full_path = PathBuf::from(cwd);
-    match &args.positional[0] {
+    match &(args.positional[0].item) {
         Value::Primitive(Primitive::String(s)) => full_path.push(Path::new(s)),
         _ => {}
     }
 
     let save_raw = match args.positional.get(1) {
-        Some(Value::Primitive(Primitive::String(s))) if s == "--raw" => true,
+        Some(Spanned {
+            item: Value::Primitive(Primitive::String(s)),
+            ..
+        }) if s == "--raw" => true,
         _ => false,
     };
 

--- a/src/commands/skip.rs
+++ b/src/commands/skip.rs
@@ -2,7 +2,30 @@ use crate::errors::ShellError;
 use crate::prelude::*;
 
 pub fn skip(args: CommandArgs) -> Result<OutputStream, ShellError> {
-    let amount = args.positional[0].as_i64()?;
+    if args.positional.len() == 0 {
+        if let Some(span) = args.name_span {
+            return Err(ShellError::labeled_error(
+                "Skip requires an amount",
+                "needs parameter",
+                span,
+            ));
+        } else {
+            return Err(ShellError::string("skip requires an amount."));
+        }
+    }
+
+    let amount = args.positional[0].as_i64();
+
+    let amount = match amount {
+        Ok(o) => o,
+        Err(_) => {
+            return Err(ShellError::labeled_error(
+                "Value is not a number",
+                "expected integer",
+                args.positional[0].span,
+            ))
+        }
+    };
 
     let input = args.input;
 

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -3,10 +3,31 @@ use crate::prelude::*;
 use prettyprint::PrettyPrinter;
 
 pub fn view(args: CommandArgs) -> Result<OutputStream, ShellError> {
-    let target = match args.positional.first() {
-        // TODO: This needs better infra
-        None => return Err(ShellError::string(format!("cat must take one arg"))),
-        Some(v) => v.as_string()?.clone(),
+    if args.positional.len() == 0 {
+        if let Some(span) = args.name_span {
+            return Err(ShellError::labeled_error(
+                "View requires a filename",
+                "needs parameter",
+                span,
+            ));
+        } else {
+            return Err(ShellError::string("view requires a filename."));
+        }
+    }
+
+    let target = match args.positional[0].as_string() {
+        Ok(s) => s.clone(),
+        Err(e) => {
+            if let Some(span) = args.name_span {
+                return Err(ShellError::labeled_error(
+                    "Expected a string",
+                    "not a filename",
+                    span,
+                ));
+            } else {
+                return Err(e);
+            }
+        }
     };
 
     let cwd = args.env.lock().unwrap().cwd().to_path_buf();

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,6 @@
 use crate::commands::command::Sink;
 use crate::commands::command::SinkCommandArgs;
+use crate::parser::lexer::Span;
 use crate::parser::Args;
 use crate::prelude::*;
 
@@ -37,10 +38,6 @@ impl Context {
         }
     }
 
-    pub fn clone_sinks(&self) -> indexmap::IndexMap<String, Arc<dyn Sink>> {
-        self.sinks.clone()
-    }
-
     crate fn has_sink(&self, name: &str) -> bool {
         self.sinks.contains_key(name)
     }
@@ -52,11 +49,13 @@ impl Context {
     crate fn run_sink(
         &mut self,
         command: Arc<dyn Sink>,
+        name_span: Option<Span>,
         args: Args,
         input: Vec<Value>,
     ) -> Result<(), ShellError> {
         let command_args = SinkCommandArgs {
             ctx: self.clone(),
+            name_span,
             positional: args.positional,
             named: args.named,
             input,
@@ -80,12 +79,14 @@ impl Context {
     crate fn run_command(
         &mut self,
         command: Arc<dyn Command>,
+        name_span: Option<Span>,
         args: Args,
         input: InputStream,
     ) -> Result<OutputStream, ShellError> {
         let command_args = CommandArgs {
             host: self.host.clone(),
             env: self.env.clone(),
+            name_span,
             positional: args.positional,
             named: args.named,
             input,

--- a/src/evaluate/evaluator.rs
+++ b/src/evaluate/evaluator.rs
@@ -1,5 +1,6 @@
 use crate::object::Primitive;
 use crate::parser::ast;
+use crate::parser::lexer::Spanned;
 use crate::prelude::*;
 use derive_new::new;
 use indexmap::IndexMap;
@@ -20,17 +21,25 @@ impl Scope {
     }
 }
 
-crate fn evaluate_expr(expr: &ast::Expression, scope: &Scope) -> Result<Value, ShellError> {
+crate fn evaluate_expr(
+    expr: &ast::Expression,
+    scope: &Scope,
+) -> Result<Spanned<Value>, ShellError> {
     use ast::*;
     match &expr.expr {
         RawExpression::Call(_) => Err(ShellError::unimplemented("Evaluating call expression")),
-        RawExpression::Leaf(l) => Ok(evaluate_leaf(l)),
+        RawExpression::Leaf(l) => Ok(Spanned::from_item(evaluate_leaf(l), expr.span.clone())),
         RawExpression::Parenthesized(p) => evaluate_expr(&p.expr, scope),
-        RawExpression::Flag(f) => Ok(Value::Primitive(Primitive::String(f.print()))),
+        RawExpression::Flag(f) => Ok(Spanned::from_item(
+            Value::Primitive(Primitive::String(f.print())),
+            expr.span.clone(),
+        )),
         RawExpression::Block(b) => evaluate_block(&b, scope),
         RawExpression::Path(p) => evaluate_path(&p, scope),
         RawExpression::Binary(b) => evaluate_binary(b, scope),
-        RawExpression::VariableReference(r) => evaluate_reference(r, scope),
+        RawExpression::VariableReference(r) => {
+            evaluate_reference(r, scope).map(|x| Spanned::from_item(x, expr.span.clone()))
+        }
     }
 }
 
@@ -59,12 +68,15 @@ fn evaluate_reference(r: &ast::Variable, scope: &Scope) -> Result<Value, ShellEr
     }
 }
 
-fn evaluate_binary(binary: &ast::Binary, scope: &Scope) -> Result<Value, ShellError> {
+fn evaluate_binary(binary: &ast::Binary, scope: &Scope) -> Result<Spanned<Value>, ShellError> {
     let left = evaluate_expr(&binary.left, scope)?;
     let right = evaluate_expr(&binary.right, scope)?;
 
     match left.compare(&binary.operator, &right) {
-        Some(v) => Ok(Value::boolean(v)),
+        Some(v) => Ok(Spanned::from_item(
+            Value::boolean(v),
+            binary.operator.span.clone(),
+        )),
         None => Err(ShellError::TypeError(format!(
             "Can't compare {} and {}",
             left.type_name(),
@@ -73,13 +85,16 @@ fn evaluate_binary(binary: &ast::Binary, scope: &Scope) -> Result<Value, ShellEr
     }
 }
 
-fn evaluate_block(block: &ast::Block, _scope: &Scope) -> Result<Value, ShellError> {
-    Ok(Value::block(block.expr.clone()))
+fn evaluate_block(block: &ast::Block, _scope: &Scope) -> Result<Spanned<Value>, ShellError> {
+    Ok(Spanned::from_item(
+        Value::block(block.expr.clone()),
+        block.expr.span.clone(),
+    ))
 }
 
-fn evaluate_path(path: &ast::Path, scope: &Scope) -> Result<Value, ShellError> {
+fn evaluate_path(path: &ast::Path, scope: &Scope) -> Result<Spanned<Value>, ShellError> {
     let head = path.head();
-    let mut value = &evaluate_expr(head, scope)?;
+    let mut value = evaluate_expr(head, scope)?;
     let mut seen = vec![];
 
     for name in path.tail() {
@@ -93,9 +108,9 @@ fn evaluate_path(path: &ast::Path, scope: &Scope) -> Result<Value, ShellError> {
                     subpath: itertools::join(seen, "."),
                 });
             }
-            Some(v) => value = v,
+            Some(v) => value = Spanned::from_item(v.copy(), name.span.clone()),
         }
     }
 
-    Ok(value.copy())
+    Ok(value)
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -6,9 +6,8 @@ crate mod tree;
 
 use crate::prelude::*;
 
-crate use entries::{EntriesListView, EntriesView};
+crate use entries::EntriesView;
 crate use generic::GenericView;
-crate use list::ListView;
 crate use table::TableView;
 crate use tree::TreeView;
 

--- a/src/format/entries.rs
+++ b/src/format/entries.rs
@@ -55,36 +55,3 @@ impl RenderView for EntriesView {
         Ok(())
     }
 }
-
-pub struct EntriesListView {
-    values: VecDeque<Value>,
-}
-
-impl EntriesListView {
-    crate async fn from_stream(values: InputStream) -> EntriesListView {
-        EntriesListView {
-            values: values.collect().await,
-        }
-    }
-}
-
-impl RenderView for EntriesListView {
-    fn render_view(&self, host: &mut dyn Host) -> Result<(), ShellError> {
-        if self.values.len() == 0 {
-            return Ok(());
-        }
-
-        let last = self.values.len() - 1;
-
-        for (i, item) in self.values.iter().enumerate() {
-            let view = EntriesView::from_value(item);
-            view.render_view(host)?;
-
-            if i != last {
-                host.stdout("\n");
-            }
-        }
-
-        Ok(())
-    }
-}

--- a/src/format/generic.rs
+++ b/src/format/generic.rs
@@ -1,4 +1,4 @@
-use crate::format::{EntriesView, ListView, RenderView, TableView, TreeView};
+use crate::format::{EntriesView, RenderView, TableView};
 use crate::object::Value;
 use crate::prelude::*;
 use derive_new::new;

--- a/src/format/tree.rs
+++ b/src/format/tree.rs
@@ -21,7 +21,9 @@ pub struct TreeView {
 impl TreeView {
     fn from_value_helper(value: &Value, mut builder: &mut TreeBuilder) {
         match value {
-            Value::Primitive(p) => builder = builder.add_empty_child(p.format(None)),
+            Value::Primitive(p) => {
+                let _ = builder.add_empty_child(p.format(None));
+            }
             Value::Object(o) => {
                 for (k, v) in o.entries.iter() {
                     builder = builder.begin_child(k.name.display().to_string());

--- a/src/object/base.rs
+++ b/src/object/base.rs
@@ -2,6 +2,7 @@ use crate::errors::ShellError;
 use crate::evaluate::{evaluate_expr, Scope};
 use crate::object::DataDescriptor;
 use crate::parser::ast::{self, Operator};
+use crate::parser::lexer::Spanned;
 use crate::prelude::*;
 use ansi_term::Color;
 use chrono::{DateTime, Utc};
@@ -142,7 +143,7 @@ impl Deserialize<'de> for Block {
 }
 
 impl Block {
-    pub fn invoke(&self, value: &Value) -> Result<Value, ShellError> {
+    pub fn invoke(&self, value: &Value) -> Result<Spanned<Value>, ShellError> {
         let scope = Scope::new(value.copy());
         evaluate_expr(&self.expression, &scope)
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,7 +26,7 @@ pub fn parse(input: &str) -> Result<Pipeline, ShellError> {
 
     match parser.parse(tokens) {
         Ok(val) => Ok(val),
-        Err(err) => Err(ShellError::parse_error(err, input.to_string())),
+        Err(err) => Err(ShellError::parse_error(err)),
     }
 }
 
@@ -39,11 +39,11 @@ mod tests {
     fn assert_parse(source: &str, expected: Pipeline) {
         let parsed = match parse(source) {
             Ok(p) => p,
-            Err(ShellError::Diagnostic(diag, source)) => {
+            Err(ShellError::Diagnostic(diag)) => {
                 use language_reporting::termcolor;
 
                 let writer = termcolor::StandardStream::stdout(termcolor::ColorChoice::Auto);
-                let files = crate::parser::span::Files::new(source);
+                let files = crate::parser::span::Files::new(source.to_string());
 
                 language_reporting::emit(
                     &mut writer.lock(),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -558,13 +558,12 @@ impl Iterator for Lexer<'source> {
     }
 }
 
-fn lex_error(range: &Range<usize>, source: &str) -> ShellError {
+fn lex_error(range: &Range<usize>, _source: &str) -> ShellError {
     use language_reporting::*;
 
     ShellError::diagnostic(
         Diagnostic::new(Severity::Error, "Lex error")
             .with_label(Label::new_primary(Span::new(range))),
-        source.to_string(),
     )
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,7 +7,7 @@ crate use crate::errors::ShellError;
 crate use crate::object::Value;
 crate use crate::parser::ast;
 crate use crate::stream::{single_output, InputStream, OutputStream};
-crate use futures::{FutureExt, SinkExt, StreamExt};
+crate use futures::{FutureExt, StreamExt};
 crate use std::collections::VecDeque;
 crate use std::pin::Pin;
 crate use std::sync::{Arc, Mutex};

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -4,10 +4,6 @@ use futures::stream::BoxStream;
 pub type InputStream = BoxStream<'static, Value>;
 pub type OutputStream = BoxStream<'static, ReturnValue>;
 
-crate fn empty_stream() -> OutputStream {
-    VecDeque::new().boxed()
-}
-
 crate fn single_output(item: Value) -> OutputStream {
     let value = ReturnValue::Value(item);
     let mut vec = VecDeque::new();


### PR DESCRIPTION
Adds pretty printing of errors. Moves many of the commands over to use these new diagnostics. To do this, we plumb the spans all the way through to the commands (including to the names of the commands from the input)