### PR TITLE
Move back onto main subprocess

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ dependencies = [
  "serde_ini 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "subprocess 0.1.19 (git+https://github.com/jonathandturner/rust-subprocess.git?branch=is_already_escaped)",
+ "subprocess 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "sysinfo 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2588,8 +2588,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "subprocess"
-version = "0.1.19"
-source = "git+https://github.com/jonathandturner/rust-subprocess.git?branch=is_already_escaped#6d184a680d825da4f365c063db1c4f9db3d64ba6"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3471,7 +3471,7 @@ dependencies = [
 "checksum string 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0bbfb8937e38e34c3444ff00afb28b0811d9554f15c5ad64d12b0308d1d1995"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum subprocess 0.1.19 (git+https://github.com/jonathandturner/rust-subprocess.git?branch=is_already_escaped)" = "<none>"
+"checksum subprocess 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "28fc0f40f0c0da73339d347aa7d6d2b90341a95683a47722bc4eebed71ff3c00"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,14 +62,11 @@ reqwest = "0.9"
 roxmltree = "0.6.0"
 pretty = "0.5.2"
 serde_ini = "0.2.0"
+subprocess = "0.1.18"
 
 [dependencies.pancurses]
 version = "0.16"
 features = ["win32a"]
-
-[dependencies.subprocess]
-git = "https://github.com/jonathandturner/rust-subprocess.git"
-branch = "is_already_escaped"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/src/commands/classified.rs
+++ b/src/commands/classified.rs
@@ -184,6 +184,7 @@ impl ExternalCommand {
         }
 
         let mut process;
+
         #[cfg(windows)]
         {
             process = Exec::shell(&self.name);
@@ -267,6 +268,7 @@ impl ExternalCommand {
                     new_arg_string.push_str(&arg);
                 }
             }
+
             process = Exec::shell(new_arg_string);
         }
         process = process.cwd(context.env.lock().unwrap().front().unwrap().path());

--- a/src/parser/ast/expression.rs
+++ b/src/parser/ast/expression.rs
@@ -383,7 +383,16 @@ impl Leaf {
 
     fn as_external_arg(&self) -> String {
         match self {
-            Leaf::String(s) => format!("\"{}\"", s),
+            Leaf::String(s) => {
+                #[cfg(windows)]
+                {
+                    format!("{}", s)
+                }
+                #[cfg(not(windows))]
+                {
+                    format!("\"{}\"", s)
+                }
+            }
             Leaf::Bare(path) => format!("{}", path.to_string()),
             Leaf::Boolean(b) => format!("{}", b),
             Leaf::Int(i) => format!("{}", i),


### PR DESCRIPTION
This (hopefully) will be sufficient to move back onto mainline subprocess. It doesn't work exactly the same, specifically a single word quoted string argument like `echo "foo"` won't print the exact same way that it does in cmd, but it should work for multi-word quotes like `echo "foo bar"`.  Commands like git that were tripped up before by the quotes seem to work okay now.